### PR TITLE
fix(stop hook): disambiguate code-simplify from built-in simplify

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, invoke the code-simplify skill to review the code you modified this session. If no code was modified, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, invoke the code-simplify skill to review the code you modified this session. If no code was modified, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -35,4 +35,4 @@ lock="${TMPDIR:-/tmp}/simplify-on-stop-${session_id}.lock"
 # the nudge for this session, which is strictly better than looping.)
 : > "$lock" 2>/dev/null || exit 0
 
-echo '{"decision":"block","reason":"Before stopping, invoke the code-simplify skill to review the code you modified this session. If no code was modified, skip the skill and conclude."}'
+echo '{"decision":"block","reason":"Before stopping, call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\" skill) to review code you modified this session. If you modified no code, skip the skill and conclude."}'


### PR DESCRIPTION
## Summary

The harness ships a built-in `simplify` skill that overlaps in name and purpose with our project `code-simplify` skill. The Stop hook reason text named `code-simplify`, but the agent routinely launched the built-in `simplify` instead.

Tighten the hook's `reason` payload to name the Skill tool argument explicitly (`skill="code-simplify"`) and disambiguate from the built-in `simplify`.

## Test plan
- [ ] Stop hook still produces valid JSON
- [ ] `agent_sync.py --dry-run` reports no differences after sync
- [ ] On a fresh session that modifies code, the agent invokes `code-simplify` (not `simplify`)

---
_Generated by [Claude Code](https://claude.ai/code/session_017wz74XXFHLjRaCSohr7EYW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to hook instruction strings; no runtime logic or security paths affected.
> 
> **Overview**
> Updates the Stop hook’s block **`reason`** in **`.agents`**, **`.claude`**, and **`.cursor`** copies of `simplify-on-stop.sh` so agents are told to use the **Skill** tool with **`skill="code-simplify"`** and to avoid the harness built-in **`simplify`** skill.
> 
> The hook behavior (lock, `stop_hook_active`, JSON shape) is unchanged; only the instruction text is clearer so the project review skill runs instead of the wrong one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41be8d4860a8b3b8fd3952026f249f18a13091c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->