### PR TITLE
rename(skill): ultra-review -> ultra-refactor; ban slim shims

### DIFF
--- a/.agents/agents/ultra-review.md
+++ b/.agents/agents/ultra-review.md
@@ -1,7 +1,7 @@
 ---
 name: ultra-review
-description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-review` skill as the complete rubric.
-skills: [ultra-review]
+description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-refactor` skill as the complete rubric.
+skills: [ultra-refactor]
 ---
 
 # Ultra Code Quality Review
@@ -10,7 +10,7 @@ You are a **Task subagent**. The parent agent already collected git output and c
 
 ## Rubric
 
-Apply the `ultra-review` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
+Apply the `ultra-refactor` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
 
 ## Work
 

--- a/.agents/skills/ultra-refactor/SKILL.md
+++ b/.agents/skills/ultra-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: ultra-review
-description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra review, ultra-review, deep code quality audit, or especially harsh maintainability review.
+name: ultra-refactor
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra refactor, ultra-refactor, deep code quality audit, or especially harsh maintainability review.
 ---
 
 # Ultra Code Quality Review

--- a/.agents/skills/ultra-refactor/SKILL.md
+++ b/.agents/skills/ultra-refactor/SKILL.md
@@ -50,7 +50,16 @@ Apply the baseline prompt above, plus these explicit review rules:
 4. **Prefer direct, boring, maintainable code over hacky or magical code.**
    - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
    - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
-   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+   - Forbid slim pass-through shims: a function whose body is one call to the canonical function with the same name/args is banned. Call the canonical function directly at the use-site.
+
+     ```python
+     # Bad — pass-through shim
+     async def head_object_content_type(config, *, object_key):
+         return await object_storage.head_object_content_type(backend(config), object_key=object_key)
+
+     # Good — call the canonical helper at the use-site
+     await object_storage.head_object_content_type(backend(config), object_key=object_key)
+     ```
 
 5. **Push hard on type and boundary cleanliness when they affect maintainability.**
    - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.

--- a/.claude/agents/ultra-review.md
+++ b/.claude/agents/ultra-review.md
@@ -1,8 +1,8 @@
 ---
 name: ultra-review
-description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-review` skill as the complete rubric.
+description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-refactor` skill as the complete rubric.
 skills:
-- ultra-review
+- ultra-refactor
 ---
 
 # Ultra Code Quality Review
@@ -11,7 +11,7 @@ You are a **Task subagent**. The parent agent already collected git output and c
 
 ## Rubric
 
-Apply the `ultra-review` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
+Apply the `ultra-refactor` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
 
 ## Work
 

--- a/.claude/skills/ultra-refactor/SKILL.md
+++ b/.claude/skills/ultra-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: ultra-review
-description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra review, ultra-review, deep code quality audit, or especially harsh maintainability review.
+name: ultra-refactor
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra refactor, ultra-refactor, deep code quality audit, or especially harsh maintainability review.
 ---
 
 # Ultra Code Quality Review

--- a/.claude/skills/ultra-refactor/SKILL.md
+++ b/.claude/skills/ultra-refactor/SKILL.md
@@ -50,7 +50,16 @@ Apply the baseline prompt above, plus these explicit review rules:
 4. **Prefer direct, boring, maintainable code over hacky or magical code.**
    - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
    - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
-   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+   - Forbid slim pass-through shims: a function whose body is one call to the canonical function with the same name/args is banned. Call the canonical function directly at the use-site.
+
+     ```python
+     # Bad — pass-through shim
+     async def head_object_content_type(config, *, object_key):
+         return await object_storage.head_object_content_type(backend(config), object_key=object_key)
+
+     # Good — call the canonical helper at the use-site
+     await object_storage.head_object_content_type(backend(config), object_key=object_key)
+     ```
 
 5. **Push hard on type and boundary cleanliness when they affect maintainability.**
    - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.

--- a/.codex/skills/ultra-refactor/SKILL.md
+++ b/.codex/skills/ultra-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: ultra-review
-description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra review, ultra-review, deep code quality audit, or especially harsh maintainability review.
+name: "ultra-refactor"
+description: "Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra refactor, ultra-refactor, deep code quality audit, or especially harsh maintainability review."
 ---
 
 # Ultra Code Quality Review

--- a/.codex/skills/ultra-refactor/SKILL.md
+++ b/.codex/skills/ultra-refactor/SKILL.md
@@ -50,7 +50,16 @@ Apply the baseline prompt above, plus these explicit review rules:
 4. **Prefer direct, boring, maintainable code over hacky or magical code.**
    - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
    - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
-   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+   - Forbid slim pass-through shims: a function whose body is one call to the canonical function with the same name/args is banned. Call the canonical function directly at the use-site.
+
+     ```python
+     # Bad — pass-through shim
+     async def head_object_content_type(config, *, object_key):
+         return await object_storage.head_object_content_type(backend(config), object_key=object_key)
+
+     # Good — call the canonical helper at the use-site
+     await object_storage.head_object_content_type(backend(config), object_key=object_key)
+     ```
 
 5. **Push hard on type and boundary cleanliness when they affect maintainability.**
    - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.

--- a/.cursor/agents/ultra-review.md
+++ b/.cursor/agents/ultra-review.md
@@ -1,8 +1,8 @@
 ---
 name: ultra-review
-description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-review` skill as the complete rubric.
+description: Ultra code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Uses the `ultra-refactor` skill as the complete rubric.
 skills:
-- ultra-review
+- ultra-refactor
 ---
 
 # Ultra Code Quality Review
@@ -11,7 +11,7 @@ You are a **Task subagent**. The parent agent already collected git output and c
 
 ## Rubric
 
-Apply the `ultra-review` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
+Apply the `ultra-refactor` SKILL — its `SKILL.md` is the **complete** rubric (tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules).
 
 ## Work
 

--- a/.cursor/skills/ultra-refactor/SKILL.md
+++ b/.cursor/skills/ultra-refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "ultra-review"
-description: "Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra review, ultra-review, deep code quality audit, or especially harsh maintainability review."
+name: ultra-refactor
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for an ultra refactor, ultra-refactor, deep code quality audit, or especially harsh maintainability review.
 ---
 
 # Ultra Code Quality Review

--- a/.cursor/skills/ultra-refactor/SKILL.md
+++ b/.cursor/skills/ultra-refactor/SKILL.md
@@ -50,7 +50,16 @@ Apply the baseline prompt above, plus these explicit review rules:
 4. **Prefer direct, boring, maintainable code over hacky or magical code.**
    - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
    - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
-   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+   - Forbid slim pass-through shims: a function whose body is one call to the canonical function with the same name/args is banned. Call the canonical function directly at the use-site.
+
+     ```python
+     # Bad — pass-through shim
+     async def head_object_content_type(config, *, object_key):
+         return await object_storage.head_object_content_type(backend(config), object_key=object_key)
+
+     # Good — call the canonical helper at the use-site
+     await object_storage.head_object_content_type(backend(config), object_key=object_key)
+     ```
 
 5. **Push hard on type and boundary cleanliness when they affect maintainability.**
    - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.


### PR DESCRIPTION
## Summary

- Rename the `ultra-review` skill to `ultra-refactor` (directory + frontmatter + agent `skills:` reference).
- Strengthen rule 4 in the skill with an explicit ban on slim pass-through shims, plus a short Python example showing the bad/good pattern.

## Test plan
- [ ] `agent_sync.py --dry-run` reports no differences after sync
- [ ] Skill resolves under the new name in a fresh session

---
_Generated by [Claude Code](https://claude.ai/code/session_017wz74XXFHLjRaCSohr7EYW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill wiring only; no runtime application code.
> 
> **Overview**
> Renames the maintainability skill from **`ultra-review`** to **`ultra-refactor`** across mirrored agent config trees (`.agents`, `.claude`, `.cursor`, `.codex`): skill frontmatter `name`/`description`, agent `skills:` lists, and rubric text now point at **`ultra-refactor`**.
> 
> **`ultra-review` Task subagents** keep the same `name` and `subagent_type: "ultra-review"` orchestration; only their attached rubric skill changes.
> 
> Rule **4** in the skill is tightened: **slim pass-through shims** (one-line delegates to the canonical helper with the same signature) are explicitly banned, with a short Python bad/good example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb1566c1c0cc65bbcccb3de0ad85aad0143ac163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->