### PR TITLE
refactor: drop leading underscores from non-nested names

### DIFF
--- a/.github/scripts/agent_sync.py
+++ b/.github/scripts/agent_sync.py
@@ -22,7 +22,7 @@ SETTINGS_DIR: Final[Path] = AGENTS_DIR / "settings"
 MODELS_DIR: Final[Path] = AGENTS_DIR / "models"
 MAX_DIFF_LINES: Final[int] = 20
 SAFE_SLUG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-_TEXT_CACHE: dict[Path, str | None] = {}
+TEXT_CACHE: dict[Path, str | None] = {}
 
 
 class OutputFile(BaseModel):
@@ -691,13 +691,13 @@ def compute_diffs(outputs: list[OutputFile]) -> list[DiffEntry]:
         # Content matches but the exec bit may be missing — rewrite so write_text
         # re-applies chmod. Without this, a Stop hook command pointing at a bare
         # script path can fail.
-        if _output_needs_exec_bit(output) and output.target_path.exists() \
+        if output_needs_exec_bit(output) and output.target_path.exists() \
                 and not output.target_path.stat().st_mode & 0o111:
             diffs.append(DiffEntry(output=output, existing=existing))
     return diffs
 
 
-def _output_needs_exec_bit(output: OutputFile) -> bool:
+def output_needs_exec_bit(output: OutputFile) -> bool:
     return output.target_path.suffix == ".sh" or output.content.startswith("#!")
 
 
@@ -790,15 +790,15 @@ def compute_stale_paths(
 def read_text(path: Path) -> str | None:
     """Read a file with caching to avoid repeated disk reads."""
 
-    if path in _TEXT_CACHE:
-        return _TEXT_CACHE[path]
+    if path in TEXT_CACHE:
+        return TEXT_CACHE[path]
 
     if not path.exists():
-        _TEXT_CACHE[path] = None
+        TEXT_CACHE[path] = None
         return None
 
     content = path.read_text(encoding="utf-8")
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
     return content
 
 
@@ -809,7 +809,7 @@ def write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     if path.suffix == ".sh" or content.startswith("#!"):
         path.chmod(0o755)
-    _TEXT_CACHE[path] = content
+    TEXT_CACHE[path] = content
 
 
 def delete_path(path: Path) -> None:
@@ -820,13 +820,13 @@ def delete_path(path: Path) -> None:
 
     if path.is_dir():
         shutil.rmtree(path)
-        stale_keys = [cached_path for cached_path in _TEXT_CACHE if cached_path.is_relative_to(path)]
+        stale_keys = [cached_path for cached_path in TEXT_CACHE if cached_path.is_relative_to(path)]
         for stale_key in stale_keys:
-            _TEXT_CACHE.pop(stale_key, None)
+            TEXT_CACHE.pop(stale_key, None)
         return
 
     path.unlink(missing_ok=True)
-    _TEXT_CACHE.pop(path, None)
+    TEXT_CACHE.pop(path, None)
 
 
 def report_diffs(diffs: list[DiffEntry], stale_paths: list[Path]) -> None:
@@ -936,7 +936,7 @@ def dedupe_directory(directory: Path) -> None:
         keep = choose_preferred(seen[digest], path)
         remove = path if keep == seen[digest] else seen[digest]
         remove.unlink(missing_ok=True)
-        _TEXT_CACHE.pop(remove, None)
+        TEXT_CACHE.pop(remove, None)
         seen[digest] = keep
 
 

--- a/fastapi_custom_responses/errors.py
+++ b/fastapi_custom_responses/errors.py
@@ -63,7 +63,7 @@ class ErrorResponse(Exception):
         )
 
 
-def _format_field_location(loc: tuple[int | str, ...]) -> str:
+def format_field_location(loc: tuple[int | str, ...]) -> str:
     """Extract the field name from a validation error location tuple."""
 
     # Filter out 'body', 'query', 'path' prefixes and join remaining parts
@@ -76,7 +76,7 @@ def _format_field_location(loc: tuple[int | str, ...]) -> str:
     return ".".join(field_parts)
 
 
-def _format_number(value: int | float) -> str:
+def format_number(value: int | float) -> str:
     """Format a numeric constraint value for display, stripping unnecessary '.0' from whole floats."""
 
     if isinstance(value, float) and value.is_integer():
@@ -125,7 +125,7 @@ CONSTRAINT_RULES: Final[dict[str, ConstraintRule]] = {
 }
 
 
-def _format_constraint_error(field: str, ctx: dict, rule: ConstraintRule) -> str:
+def format_constraint_error(field: str, ctx: dict, rule: ConstraintRule) -> str:
     """Format a constraint violation from its rule, falling back when the bound is absent from ctx."""
 
     value = ctx.get(rule.ctx_key)
@@ -134,13 +134,13 @@ def _format_constraint_error(field: str, ctx: dict, rule: ConstraintRule) -> str
 
     unit = "item" if value == 1 else "items"
 
-    return f"Field '{field}' {rule.template.format(value=_format_number(value), unit=unit)}"
+    return f"Field '{field}' {rule.template.format(value=format_number(value), unit=unit)}"
 
 
-def _format_single_error(error: dict) -> str:
+def format_single_error(error: dict) -> str:
     """Format a single Pydantic validation error into a human-readable message."""
 
-    field = _format_field_location(error.get("loc", ()))
+    field = format_field_location(error.get("loc", ()))
     error_type = error.get("type", "")
     msg = error.get("msg", "")
     ctx = error.get("ctx", {})
@@ -150,7 +150,7 @@ def _format_single_error(error: dict) -> str:
 
     rule = CONSTRAINT_RULES.get(error_type)
     if rule is not None:
-        return _format_constraint_error(field, ctx, rule)
+        return format_constraint_error(field, ctx, rule)
 
     match error_type:
         case "enum":
@@ -171,7 +171,7 @@ def _format_single_error(error: dict) -> str:
             return f"Field '{field}' is invalid"
 
 
-def _format_validation_errors(exc: RequestValidationError) -> str:
+def format_validation_errors(exc: RequestValidationError) -> str:
     """Format all validation errors into a single human-readable message."""
 
     errors = exc.errors()
@@ -179,10 +179,10 @@ def _format_validation_errors(exc: RequestValidationError) -> str:
     if not errors:
         return ERROR_MESSAGES[HTTPStatus.BAD_REQUEST]
 
-    return ". ".join(_format_single_error(error) for error in errors)
+    return ". ".join(format_single_error(error) for error in errors)
 
 
-def _error_json_response(status_code: int, error: str) -> JSONResponse:
+def error_json_response(status_code: int, error: str) -> JSONResponse:
     """Build the standard `{success: false, error: ...}` JSON response."""
 
     response = Response(success=False, error=error)
@@ -190,52 +190,52 @@ def _error_json_response(status_code: int, error: str) -> JSONResponse:
     return JSONResponse(status_code=status_code, content=response.model_dump(mode="json"))
 
 
-def _validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+def validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
     """Handle validation errors from pydantic models with human-readable messages."""
 
     logger.warning("Validation error: %s", exc.errors())
 
-    return _error_json_response(HTTPStatus.BAD_REQUEST, _format_validation_errors(exc))
+    return error_json_response(HTTPStatus.BAD_REQUEST, format_validation_errors(exc))
 
 
-def _value_error_handler(_: Request, exc: ValueError) -> JSONResponse:
+def value_error_handler(_: Request, exc: ValueError) -> JSONResponse:
     """Handle value errors, e.g., Pydantic validation errors."""
 
     logger.exception(exc)
 
-    return _error_json_response(HTTPStatus.BAD_REQUEST, str(exc))
+    return error_json_response(HTTPStatus.BAD_REQUEST, str(exc))
 
 
-def _error_response_handler(_: Request, exc: ErrorResponse) -> JSONResponse:
+def error_response_handler(_: Request, exc: ErrorResponse) -> JSONResponse:
     """Convert ErrorResponse exceptions to proper JSONResponse objects."""
 
     logger.info("ErrorResponse: %s - %s", exc.status_code, exc.error)
 
-    return _error_json_response(exc.status_code, exc.error)
+    return error_json_response(exc.status_code, exc.error)
 
 
-def _general_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+def general_exception_handler(_: Request, exc: Exception) -> JSONResponse:
     """Handle all unhandled exceptions."""
 
     logger.exception(exc)
 
-    return _error_json_response(
+    return error_json_response(
         HTTPStatus.INTERNAL_SERVER_ERROR, ERROR_MESSAGES[HTTPStatus.INTERNAL_SERVER_ERROR]
     )
 
 
-def _http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
+def http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
     """Convert HTTPException to our standard error format."""
 
     error_message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
 
-    return _error_json_response(exc.status_code, error_message)
+    return error_json_response(exc.status_code, error_message)
 
 
 EXCEPTION_HANDLERS: dict[type[Exception], Callable[[Request, Exception], JSONResponse]] = {
-    HTTPException: _http_exception_handler,
-    RequestValidationError: _validation_exception_handler,
-    ValueError: _value_error_handler,
-    ErrorResponse: _error_response_handler,
-    Exception: _general_exception_handler,
+    HTTPException: http_exception_handler,
+    RequestValidationError: validation_exception_handler,
+    ValueError: value_error_handler,
+    ErrorResponse: error_response_handler,
+    Exception: general_exception_handler,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 from fastapi_custom_responses import EXCEPTION_HANDLERS, ErrorResponse
 
 
-class _TestPayload(BaseModel):
+class ValidationPayload(BaseModel):
     """Test model for validation error tests."""
 
     name: str
@@ -18,7 +18,7 @@ class _TestPayload(BaseModel):
     email: str
 
 
-class _Color(str, Enum):
+class Color(str, Enum):
     """Test enum for enum validation tests."""
 
     RED = "red"
@@ -26,17 +26,17 @@ class _Color(str, Enum):
     BLUE = "blue"
 
 
-class _ConstrainedPayload(BaseModel):
+class ConstrainedPayload(BaseModel):
     """Test model with field constraints for detailed error messages."""
 
     username: str = Field(..., min_length=3, max_length=20)
     score: int = Field(..., ge=0, le=100)
     rating: float = Field(..., gt=0, lt=5)
-    color: _Color
+    color: Color
     tags: list[str] = Field(..., min_length=1, max_length=5)
 
 
-class _ValueErrorPayload(BaseModel):
+class ValueErrorPayload(BaseModel):
     """Test model with a custom validator that raises ValueError."""
 
     code: str
@@ -52,21 +52,21 @@ class _ValueErrorPayload(BaseModel):
         return v
 
 
-def _create_test_app() -> FastAPI:
+def create_test_app() -> FastAPI:
     """Create a minimal FastAPI app with exception handlers for testing."""
 
     app = FastAPI(exception_handlers=EXCEPTION_HANDLERS)
 
     @app.post("/validate")
-    async def validate_endpoint(payload: _TestPayload) -> dict:
+    async def validate_endpoint(payload: ValidationPayload) -> dict:
         return {"success": True, "data": payload.model_dump()}
 
     @app.post("/validate-constrained")
-    async def validate_constrained_endpoint(payload: _ConstrainedPayload) -> dict:
+    async def validate_constrained_endpoint(payload: ConstrainedPayload) -> dict:
         return {"success": True, "data": payload.model_dump()}
 
     @app.post("/validate-value-error")
-    async def validate_value_error_endpoint(payload: _ValueErrorPayload) -> dict:
+    async def validate_value_error_endpoint(payload: ValueErrorPayload) -> dict:
         return {"success": True, "data": payload.model_dump()}
 
     @app.get("/error-response")
@@ -100,7 +100,7 @@ def _create_test_app() -> FastAPI:
 def app() -> FastAPI:
     """FastAPI app fixture."""
 
-    return _create_test_app()
+    return create_test_app()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,9 +3,9 @@ from http import HTTPStatus
 from httpx import AsyncClient
 import pytest
 
-from fastapi_custom_responses.errors import _format_field_location, _format_single_error
+from fastapi_custom_responses.errors import format_field_location, format_single_error
 
-_VALID_CONSTRAINED_PAYLOAD: dict = {
+VALID_CONSTRAINED_PAYLOAD: dict = {
     "username": "alice",
     "score": 50,
     "rating": 2.5,
@@ -115,7 +115,7 @@ class TestConstrainedValidationErrors:
     ) -> None:
         """Test that constrained field violations produce specific error messages."""
 
-        payload = {**_VALID_CONSTRAINED_PAYLOAD, **payload_override}
+        payload = {**VALID_CONSTRAINED_PAYLOAD, **payload_override}
         response = await self.client.post("/validate-constrained", json=payload)
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -126,7 +126,7 @@ class TestConstrainedValidationErrors:
     async def test_enum_includes_expected_values(self) -> None:
         """Test that enum error includes the allowed values."""
 
-        payload = {**_VALID_CONSTRAINED_PAYLOAD, "color": "purple"}
+        payload = {**VALID_CONSTRAINED_PAYLOAD, "color": "purple"}
         response = await self.client.post("/validate-constrained", json=payload)
 
         assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -148,7 +148,7 @@ class TestConstrainedValidationErrors:
     async def test_valid_constrained_request_succeeds(self) -> None:
         """Test that a valid request with all constraints met succeeds."""
 
-        response = await self.client.post("/validate-constrained", json=_VALID_CONSTRAINED_PAYLOAD)
+        response = await self.client.post("/validate-constrained", json=VALID_CONSTRAINED_PAYLOAD)
 
         assert response.status_code == HTTPStatus.OK
         data = response.json()
@@ -249,7 +249,7 @@ class TestGeneralExceptionHandler:
 
 
 class TestFormatFieldLocation:
-    """Tests for _format_field_location helper."""
+    """Tests for format_field_location helper."""
 
     @pytest.mark.parametrize(
         ("loc", "expected"),
@@ -265,11 +265,11 @@ class TestFormatFieldLocation:
     def test_format_field_location(self, loc: tuple, expected: str) -> None:
         """Test that field location tuples are formatted into human-readable names."""
 
-        assert _format_field_location(loc) == expected
+        assert format_field_location(loc) == expected
 
 
 class TestFormatSingleError:
-    """Tests for _format_single_error helper."""
+    """Tests for format_single_error helper."""
 
     @pytest.mark.parametrize(
         ("error", "expected"),
@@ -452,4 +452,4 @@ class TestFormatSingleError:
     def test_format_single_error(self, error: dict, expected: str) -> None:
         """Test that validation error dicts are formatted into human-readable messages."""
 
-        assert _format_single_error(error) == expected
+        assert format_single_error(error) == expected


### PR DESCRIPTION
## Summary

Enforces the updated leading-underscore convention: a leading underscore is allowed **only** for nested definitions. All other names drop it.

### Changes
- `fastapi_custom_responses/errors.py`: dropped the underscore from all module-level helpers and the exception handlers (`format_field_location`, `format_number`, `format_constraint_error`, `format_single_error`, `format_validation_errors`, `error_json_response`, `validation_exception_handler`, `value_error_handler`, `error_response_handler`, `general_exception_handler`, `http_exception_handler`) and updated the `EXCEPTION_HANDLERS` mapping plus all call sites.
- `tests/conftest.py`: renamed the test-only models/helpers (`_Color` → `Color`, `_ConstrainedPayload` → `ConstrainedPayload`, `_ValueErrorPayload` → `ValueErrorPayload`, `_create_test_app` → `create_test_app`). `_TestPayload` → `ValidationPayload` (a `Test*`-named class would be collected by pytest, so a distinct name was chosen).
- `tests/test_errors.py`: updated imports/refs and `_VALID_CONSTRAINED_PAYLOAD` → `VALID_CONSTRAINED_PAYLOAD`.
- `.github/scripts/agent_sync.py`: `_TEXT_CACHE` → `TEXT_CACHE`, `_output_needs_exec_bit` → `output_needs_exec_bit`.

### Verification
- `pytest` → **47 passed**, no collection warnings.
- Grep confirms no remaining in-scope leading-underscore definitions.

https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfNPPwW2cfLaSeexRGrhBw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical renames only; no logic or API contract changes beyond public symbol names in the errors module.
> 
> **Overview**
> Aligns naming with a convention where a **leading underscore is only for nested definitions**: module-level helpers and handlers lose the prefix, with call sites and `EXCEPTION_HANDLERS` updated accordingly.
> 
> In **`fastapi_custom_responses/errors.py`**, helpers like `format_field_location`, `format_single_error`, `error_json_response`, and the FastAPI exception handlers are renamed (e.g. `_validation_exception_handler` → `validation_exception_handler`) without behavior changes. **Tests** import the public names and rename fixtures/models (`ValidationPayload`, `VALID_CONSTRAINED_PAYLOAD`, `create_test_app`, etc.); `_TestPayload` becomes `ValidationPayload` to avoid pytest collecting a `Test*` class. **`.github/scripts/agent_sync.py`** renames `_TEXT_CACHE` → `TEXT_CACHE` and `_output_needs_exec_bit` → `output_needs_exec_bit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a23ec0b0280c014de86259d046adf4fcfd920f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->