### PR TITLE
ci: run only code-simplify in the simplify-on-stop pre-push pass

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: once per branch, nudge the agent to run claude-review and
-# code-simplify over the whole branch diff as a local pre-push pass — then stay
-# quiet. After a branch has been nudged once, later stops on it (the review
-# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
-# `stop_hook_active` guards the immediate continuation; a per-branch record in
-# the git dir guards every stop after that. If the active flag cannot be read,
-# treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
+# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
+# limits the nudge to once per branch state — gating on unpushed work would
+# never fire in remote sessions, which push within the same turn.
+# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
+# read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -24,47 +23,49 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Resolve the remote default branch once via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; reused for the detached-HEAD
-# key and the clean-tree skip below.
-default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-if [ -z "$default_ref" ]; then
-  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-  done
-fi
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(
+  {
+    git diff --binary HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
+state="$head_sha:$dirty_sha"
 
-# Key the once-per-branch record by branch name. On a detached HEAD there is no
-# branch name, so key on the fork point from the default branch — stable as the
-# detached line gains commits, unlike HEAD itself, which would rotate every
-# commit and re-fire the pass.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
-if [ -z "$branch_key" ]; then
-  fork_point=""
-  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  branch_key="detached:${fork_point:-unknown}"
-fi
-
-# Already nudged this branch — do not re-run the pass for the review's own
-# commit, a CI-fix follow-up push, or any later work on the same branch.
-nudged_file="$git_dir/simplify-on-stop.nudged"
-if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
-  exit 0
-fi
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
-# missing default ref or git error falls through and still nudges.
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 
-# Record this branch as nudged before blocking, so the pass runs exactly once.
-printf '%s\n' "$branch_key" >> "$nudged_file"
+printf '%s' "$state" > "$stamp_file"
 
-echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. Call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over that diff and apply its simplifications directly (no PR, no asking, no branching off, no comment). Commit the edits, and push them if the branch was already pushed. If the branch has no code changes, skip the skill and conclude."}'

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
-# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
-# limits the nudge to once per branch state — gating on unpushed work would
-# never fire in remote sessions, which push within the same turn.
-# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
-# read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the branch diff before a
+# push. A HEAD + working-tree stamp fires once per branch state; stop_hook_active
+# (or an unreadable flag) exits clean to avoid a second block / infinite loop.
 
 set -euo pipefail
 
@@ -18,16 +15,12 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree (a bare repo has none) there is nothing to push or
-# diff, so let Stop complete. Check the work tree first, then take the git dir.
+# Nothing to push or diff outside a work tree (a bare repo has none).
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
+# State = HEAD + working-tree content (binary-safe diff plus untracked blobs), so
+# any content change re-fires. An unreadable status stays non-empty to nudge.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
@@ -45,12 +38,8 @@ state="$head_sha:$dirty_sha"
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
-# Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# Skip a clean tree with no diff over the remote default (origin/HEAD, else
+# origin/main or origin/master); a missing ref or git error falls through.
 if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then

--- a/.agents/skills/claude-review/SKILL.md
+++ b/.agents/skills/claude-review/SKILL.md
@@ -9,21 +9,11 @@ Review a GitHub pull request using parallel specialized agents, confidence scori
 
 **Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope: flag them and fix them alongside the PR's own issues. Never dismiss a finding solely because it predates this PR.
 
-## Local / pre-push mode
-
-When this skill is invoked **outside a GitHub PR** — for example by the Stop hook before a push, or whenever the caller asks for a local review of the branch — adapt the flow:
-
-- Review the **local branch diff** — `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds — where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). The merge-base anchors the diff at the branch's fork point — and, when working directly on the default branch, at the last pushed commit — so it covers branch commits **and uncommitted working-tree changes** without pulling in unrelated upstream commits. Do not fetch a PR; skip the PR discovery and eligibility checks in Steps 1–2 entirely (do not stop or ask for a PR). Still gather the rules context Step 3 needs: list the project rule files loaded for this repository (the agent's own rules directory, wherever the platform keeps it).
-- Run the Step 3 review agents and the Step 4 confidence scoring over that scope — the diff plus the untracked files — exactly as written.
-- **Apply** the surviving findings directly to the working tree and fold them into the commit being pushed. Skip the `AskUserQuestion` gate (Step 6), the separate `claude/review-fixes-*` branch (Step 7), and Step 8 entirely — never post a comment in this mode. Step 5's “skip to step 8” does not apply here: if no findings survive the filter, report that in your reply and conclude.
-
-Use the full PR flow (Steps 1–2, 6–8, and the comment format) **only** when reviewing an actual GitHub PR.
-
 ## Steps 1–2 — PR discovery and context
 
 **Step 1:** Read and execute **Step 1** of the **scope-agents** skill (repository discovery and PR detection). This returns the repository structure and — if a PR is detectable — its number and repo slug.
 
-If no PR is detected and you are reviewing a PR (not in local / pre-push mode), stop and ask the user to provide a PR number or URL.
+If no PR is detected, stop and ask the user to provide a PR number or URL.
 
 Then use a Haiku agent to check eligibility: stop without proceeding if the PR is (a) closed, (b) a draft, (c) clearly automated or trivially simple and obviously fine, or (d) already has a code review comment from you **for the PR's current head commit** — a new push since your last review makes the PR eligible again.
 
@@ -34,10 +24,10 @@ Then use a Haiku agent to check eligibility: stop without proceeding if the PR i
 
 ## Steps 3–8 — Review, scoring, approval, fixes, report
 
-Follow these steps precisely (in local / pre-push mode, the **Local / pre-push mode** section above replaces Steps 1–2 and overrides Steps 6–8):
+Follow these steps precisely:
 
-3. Launch **5 parallel Sonnet agents** to independently review the diff (the PR diff, or the local branch diff in local / pre-push mode). Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
-   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2, or locally in local / pre-push mode). Note that the rules are guidance for code generation, so not all instructions apply during review.
+3. Launch **5 parallel Sonnet agents** to independently review the PR diff. Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
+   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2). Note that the rules are guidance for code generation, so not all instructions apply during review.
    - Agent #2 (bugs): Scan the diff for obvious bugs. Focus on large bugs; ignore nitpicks and likely false positives. You may read surrounding context in the touched files; pre-existing bugs in those files are in scope.
    - Agent #3 (history): Read git blame and history of the changed files; flag bugs that only make sense in light of that history.
    - Agent #4 (prior PRs): Read previous pull requests that touched the same files; check whether comments on those PRs also apply here.
@@ -52,13 +42,13 @@ Follow these steps precisely (in local / pre-push mode, the **Local / pre-push m
 
    For rule-compliance issues: double-check that the rule file actually calls out that specific issue before scoring above 50.
 
-5. Filter out issues with a score below 80. If none remain, skip to step 8 (in local / pre-push mode: report that no findings survived and conclude — no comment).
+5. Filter out issues with a score below 80. If none remain, skip to step 8.
 
-6. *(PR flow only — skipped in local / pre-push mode.)* **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
+6. **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
 
-7. *(In local / pre-push mode: apply every finding that survived Step 5 directly to the working tree — no approval gate, no separate branch.)* In the PR flow, implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
+7. Implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
 
-8. *(PR flow only — never post a comment in local / pre-push mode.)* Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
+8. Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
 
 ## False Positives to Ignore
 

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: once per branch, nudge the agent to run claude-review and
-# code-simplify over the whole branch diff as a local pre-push pass — then stay
-# quiet. After a branch has been nudged once, later stops on it (the review
-# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
-# `stop_hook_active` guards the immediate continuation; a per-branch record in
-# the git dir guards every stop after that. If the active flag cannot be read,
-# treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
+# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
+# limits the nudge to once per branch state — gating on unpushed work would
+# never fire in remote sessions, which push within the same turn.
+# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
+# read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -24,47 +23,49 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Resolve the remote default branch once via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; reused for the detached-HEAD
-# key and the clean-tree skip below.
-default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-if [ -z "$default_ref" ]; then
-  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-  done
-fi
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(
+  {
+    git diff --binary HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
+state="$head_sha:$dirty_sha"
 
-# Key the once-per-branch record by branch name. On a detached HEAD there is no
-# branch name, so key on the fork point from the default branch — stable as the
-# detached line gains commits, unlike HEAD itself, which would rotate every
-# commit and re-fire the pass.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
-if [ -z "$branch_key" ]; then
-  fork_point=""
-  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  branch_key="detached:${fork_point:-unknown}"
-fi
-
-# Already nudged this branch — do not re-run the pass for the review's own
-# commit, a CI-fix follow-up push, or any later work on the same branch.
-nudged_file="$git_dir/simplify-on-stop.nudged"
-if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
-  exit 0
-fi
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
-# missing default ref or git error falls through and still nudges.
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 
-# Record this branch as nudged before blocking, so the pass runs exactly once.
-printf '%s\n' "$branch_key" >> "$nudged_file"
+printf '%s' "$state" > "$stamp_file"
 
-echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. Call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over that diff and apply its simplifications directly (no PR, no asking, no branching off, no comment). Commit the edits, and push them if the branch was already pushed. If the branch has no code changes, skip the skill and conclude."}'

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
-# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
-# limits the nudge to once per branch state — gating on unpushed work would
-# never fire in remote sessions, which push within the same turn.
-# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
-# read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the branch diff before a
+# push. A HEAD + working-tree stamp fires once per branch state; stop_hook_active
+# (or an unreadable flag) exits clean to avoid a second block / infinite loop.
 
 set -euo pipefail
 
@@ -18,16 +15,12 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree (a bare repo has none) there is nothing to push or
-# diff, so let Stop complete. Check the work tree first, then take the git dir.
+# Nothing to push or diff outside a work tree (a bare repo has none).
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
+# State = HEAD + working-tree content (binary-safe diff plus untracked blobs), so
+# any content change re-fires. An unreadable status stays non-empty to nudge.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
@@ -45,12 +38,8 @@ state="$head_sha:$dirty_sha"
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
-# Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# Skip a clean tree with no diff over the remote default (origin/HEAD, else
+# origin/main or origin/master); a missing ref or git error falls through.
 if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then

--- a/.claude/skills/claude-review/SKILL.md
+++ b/.claude/skills/claude-review/SKILL.md
@@ -9,21 +9,11 @@ Review a GitHub pull request using parallel specialized agents, confidence scori
 
 **Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope: flag them and fix them alongside the PR's own issues. Never dismiss a finding solely because it predates this PR.
 
-## Local / pre-push mode
-
-When this skill is invoked **outside a GitHub PR** — for example by the Stop hook before a push, or whenever the caller asks for a local review of the branch — adapt the flow:
-
-- Review the **local branch diff** — `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds — where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). The merge-base anchors the diff at the branch's fork point — and, when working directly on the default branch, at the last pushed commit — so it covers branch commits **and uncommitted working-tree changes** without pulling in unrelated upstream commits. Do not fetch a PR; skip the PR discovery and eligibility checks in Steps 1–2 entirely (do not stop or ask for a PR). Still gather the rules context Step 3 needs: list the project rule files loaded for this repository (the agent's own rules directory, wherever the platform keeps it).
-- Run the Step 3 review agents and the Step 4 confidence scoring over that scope — the diff plus the untracked files — exactly as written.
-- **Apply** the surviving findings directly to the working tree and fold them into the commit being pushed. Skip the `AskUserQuestion` gate (Step 6), the separate `claude/review-fixes-*` branch (Step 7), and Step 8 entirely — never post a comment in this mode. Step 5's “skip to step 8” does not apply here: if no findings survive the filter, report that in your reply and conclude.
-
-Use the full PR flow (Steps 1–2, 6–8, and the comment format) **only** when reviewing an actual GitHub PR.
-
 ## Steps 1–2 — PR discovery and context
 
 **Step 1:** Read and execute **Step 1** of the **scope-agents** skill (repository discovery and PR detection). This returns the repository structure and — if a PR is detectable — its number and repo slug.
 
-If no PR is detected and you are reviewing a PR (not in local / pre-push mode), stop and ask the user to provide a PR number or URL.
+If no PR is detected, stop and ask the user to provide a PR number or URL.
 
 Then use a Haiku agent to check eligibility: stop without proceeding if the PR is (a) closed, (b) a draft, (c) clearly automated or trivially simple and obviously fine, or (d) already has a code review comment from you **for the PR's current head commit** — a new push since your last review makes the PR eligible again.
 
@@ -34,10 +24,10 @@ Then use a Haiku agent to check eligibility: stop without proceeding if the PR i
 
 ## Steps 3–8 — Review, scoring, approval, fixes, report
 
-Follow these steps precisely (in local / pre-push mode, the **Local / pre-push mode** section above replaces Steps 1–2 and overrides Steps 6–8):
+Follow these steps precisely:
 
-3. Launch **5 parallel Sonnet agents** to independently review the diff (the PR diff, or the local branch diff in local / pre-push mode). Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
-   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2, or locally in local / pre-push mode). Note that the rules are guidance for code generation, so not all instructions apply during review.
+3. Launch **5 parallel Sonnet agents** to independently review the PR diff. Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
+   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2). Note that the rules are guidance for code generation, so not all instructions apply during review.
    - Agent #2 (bugs): Scan the diff for obvious bugs. Focus on large bugs; ignore nitpicks and likely false positives. You may read surrounding context in the touched files; pre-existing bugs in those files are in scope.
    - Agent #3 (history): Read git blame and history of the changed files; flag bugs that only make sense in light of that history.
    - Agent #4 (prior PRs): Read previous pull requests that touched the same files; check whether comments on those PRs also apply here.
@@ -52,13 +42,13 @@ Follow these steps precisely (in local / pre-push mode, the **Local / pre-push m
 
    For rule-compliance issues: double-check that the rule file actually calls out that specific issue before scoring above 50.
 
-5. Filter out issues with a score below 80. If none remain, skip to step 8 (in local / pre-push mode: report that no findings survived and conclude — no comment).
+5. Filter out issues with a score below 80. If none remain, skip to step 8.
 
-6. *(PR flow only — skipped in local / pre-push mode.)* **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
+6. **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
 
-7. *(In local / pre-push mode: apply every finding that survived Step 5 directly to the working tree — no approval gate, no separate branch.)* In the PR flow, implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
+7. Implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
 
-8. *(PR flow only — never post a comment in local / pre-push mode.)* Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
+8. Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
 
 ## False Positives to Ignore
 

--- a/.codex/skills/claude-review/SKILL.md
+++ b/.codex/skills/claude-review/SKILL.md
@@ -9,21 +9,11 @@ Review a GitHub pull request using parallel specialized agents, confidence scori
 
 **Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope: flag them and fix them alongside the PR's own issues. Never dismiss a finding solely because it predates this PR.
 
-## Local / pre-push mode
-
-When this skill is invoked **outside a GitHub PR** — for example by the Stop hook before a push, or whenever the caller asks for a local review of the branch — adapt the flow:
-
-- Review the **local branch diff** — `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds — where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). The merge-base anchors the diff at the branch's fork point — and, when working directly on the default branch, at the last pushed commit — so it covers branch commits **and uncommitted working-tree changes** without pulling in unrelated upstream commits. Do not fetch a PR; skip the PR discovery and eligibility checks in Steps 1–2 entirely (do not stop or ask for a PR). Still gather the rules context Step 3 needs: list the project rule files loaded for this repository (the agent's own rules directory, wherever the platform keeps it).
-- Run the Step 3 review agents and the Step 4 confidence scoring over that scope — the diff plus the untracked files — exactly as written.
-- **Apply** the surviving findings directly to the working tree and fold them into the commit being pushed. Skip the `AskUserQuestion` gate (Step 6), the separate `claude/review-fixes-*` branch (Step 7), and Step 8 entirely — never post a comment in this mode. Step 5's “skip to step 8” does not apply here: if no findings survive the filter, report that in your reply and conclude.
-
-Use the full PR flow (Steps 1–2, 6–8, and the comment format) **only** when reviewing an actual GitHub PR.
-
 ## Steps 1–2 — PR discovery and context
 
 **Step 1:** Read and execute **Step 1** of the **scope-agents** skill (repository discovery and PR detection). This returns the repository structure and — if a PR is detectable — its number and repo slug.
 
-If no PR is detected and you are reviewing a PR (not in local / pre-push mode), stop and ask the user to provide a PR number or URL.
+If no PR is detected, stop and ask the user to provide a PR number or URL.
 
 Then use a Haiku agent to check eligibility: stop without proceeding if the PR is (a) closed, (b) a draft, (c) clearly automated or trivially simple and obviously fine, or (d) already has a code review comment from you **for the PR's current head commit** — a new push since your last review makes the PR eligible again.
 
@@ -34,10 +24,10 @@ Then use a Haiku agent to check eligibility: stop without proceeding if the PR i
 
 ## Steps 3–8 — Review, scoring, approval, fixes, report
 
-Follow these steps precisely (in local / pre-push mode, the **Local / pre-push mode** section above replaces Steps 1–2 and overrides Steps 6–8):
+Follow these steps precisely:
 
-3. Launch **5 parallel Sonnet agents** to independently review the diff (the PR diff, or the local branch diff in local / pre-push mode). Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
-   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2, or locally in local / pre-push mode). Note that the rules are guidance for code generation, so not all instructions apply during review.
+3. Launch **5 parallel Sonnet agents** to independently review the PR diff. Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
+   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2). Note that the rules are guidance for code generation, so not all instructions apply during review.
    - Agent #2 (bugs): Scan the diff for obvious bugs. Focus on large bugs; ignore nitpicks and likely false positives. You may read surrounding context in the touched files; pre-existing bugs in those files are in scope.
    - Agent #3 (history): Read git blame and history of the changed files; flag bugs that only make sense in light of that history.
    - Agent #4 (prior PRs): Read previous pull requests that touched the same files; check whether comments on those PRs also apply here.
@@ -52,13 +42,13 @@ Follow these steps precisely (in local / pre-push mode, the **Local / pre-push m
 
    For rule-compliance issues: double-check that the rule file actually calls out that specific issue before scoring above 50.
 
-5. Filter out issues with a score below 80. If none remain, skip to step 8 (in local / pre-push mode: report that no findings survived and conclude — no comment).
+5. Filter out issues with a score below 80. If none remain, skip to step 8.
 
-6. *(PR flow only — skipped in local / pre-push mode.)* **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
+6. **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
 
-7. *(In local / pre-push mode: apply every finding that survived Step 5 directly to the working tree — no approval gate, no separate branch.)* In the PR flow, implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
+7. Implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
 
-8. *(PR flow only — never post a comment in local / pre-push mode.)* Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
+8. Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
 
 ## False Positives to Ignore
 

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Stop hook: once per branch, nudge the agent to run claude-review and
-# code-simplify over the whole branch diff as a local pre-push pass — then stay
-# quiet. After a branch has been nudged once, later stops on it (the review
-# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
-# `stop_hook_active` guards the immediate continuation; a per-branch record in
-# the git dir guards every stop after that. If the active flag cannot be read,
-# treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
+# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
+# limits the nudge to once per branch state — gating on unpushed work would
+# never fire in remote sessions, which push within the same turn.
+# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
+# read, treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -24,47 +23,49 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Resolve the remote default branch once via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; reused for the detached-HEAD
-# key and the clean-tree skip below.
-default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-if [ -z "$default_ref" ]; then
-  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-  done
-fi
+# State = HEAD plus a hash of the actual working-tree content, so re-editing an
+# already-modified file changes the stamp and the pre-push pass fires again
+# instead of matching a stale stamp. `git diff --binary` folds in binary file
+# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
+# file's path and contents.
+head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+dirty_sha=$(
+  {
+    git diff --binary HEAD 2>/dev/null || true
+    git ls-files --others --exclude-standard -z 2>/dev/null \
+      | while IFS= read -r -d '' file; do
+          printf '%s\0' "$file"
+          git hash-object "$file" 2>/dev/null || true
+        done
+  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
+)
+state="$head_sha:$dirty_sha"
 
-# Key the once-per-branch record by branch name. On a detached HEAD there is no
-# branch name, so key on the fork point from the default branch — stable as the
-# detached line gains commits, unlike HEAD itself, which would rotate every
-# commit and re-fire the pass.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
-if [ -z "$branch_key" ]; then
-  fork_point=""
-  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  branch_key="detached:${fork_point:-unknown}"
-fi
-
-# Already nudged this branch — do not re-run the pass for the review's own
-# commit, a CI-fix follow-up push, or any later work on the same branch.
-nudged_file="$git_dir/simplify-on-stop.nudged"
-if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
-  exit 0
-fi
+stamp_file="$git_dir/simplify-on-stop.stamp"
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
-# missing default ref or git error falls through and still nudges.
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
-  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-    exit 0
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+if [ -z "$porcelain" ]; then
+  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+  if [ -z "$default_ref" ]; then
+    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+    done
+  fi
+  if [ -n "$default_ref" ]; then
+    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+      exit 0
+    fi
   fi
 fi
 
-# Record this branch as nudged before blocking, so the pass runs exactly once.
-printf '%s\n' "$branch_key" >> "$nudged_file"
+printf '%s' "$state" > "$stamp_file"
 
-echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'
+echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. Call the Skill tool with skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over that diff and apply its simplifications directly (no PR, no asking, no branching off, no comment). Commit the edits, and push them if the branch was already pushed. If the branch has no code changes, skip the skill and conclude."}'

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run code-simplify over the whole branch diff as
-# a local pre-push pass. A stamp of HEAD + working-tree content in the git dir
-# limits the nudge to once per branch state — gating on unpushed work would
-# never fire in remote sessions, which push within the same turn.
-# `stop_hook_active` stops a second block in one stop cycle; if it cannot be
-# read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: nudge the agent to run code-simplify over the branch diff before a
+# push. A HEAD + working-tree stamp fires once per branch state; stop_hook_active
+# (or an unreadable flag) exits clean to avoid a second block / infinite loop.
 
 set -euo pipefail
 
@@ -18,16 +15,12 @@ is_active=$(printf '%s' "$input" | python3 -c \
 
 [ "$is_active" = "true" ] && exit 0
 
-# Outside a git work tree (a bare repo has none) there is nothing to push or
-# diff, so let Stop complete. Check the work tree first, then take the git dir.
+# Nothing to push or diff outside a work tree (a bare repo has none).
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
+# State = HEAD + working-tree content (binary-safe diff plus untracked blobs), so
+# any content change re-fires. An unreadable status stays non-empty to nudge.
 head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
 dirty_sha=$(
@@ -45,12 +38,8 @@ state="$head_sha:$dirty_sha"
 stamp_file="$git_dir/simplify-on-stop.stamp"
 [ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
 
-# Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# Skip a clean tree with no diff over the remote default (origin/HEAD, else
+# origin/main or origin/master); a missing ref or git error falls through.
 if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then

--- a/.cursor/skills/claude-review/SKILL.md
+++ b/.cursor/skills/claude-review/SKILL.md
@@ -9,21 +9,11 @@ Review a GitHub pull request using parallel specialized agents, confidence scori
 
 **Scope — pre-existing issues are in scope.** Do not limit the review to the lines this PR changed. Real bugs and project-rule violations that already existed in the touched files, or that the PR did not introduce, are within scope: flag them and fix them alongside the PR's own issues. Never dismiss a finding solely because it predates this PR.
 
-## Local / pre-push mode
-
-When this skill is invoked **outside a GitHub PR** — for example by the Stop hook before a push, or whenever the caller asks for a local review of the branch — adapt the flow:
-
-- Review the **local branch diff** — `git diff $(git merge-base <base> HEAD)` plus any untracked files the branch adds — where `<base>` is the repository's remote default branch (for example `origin/main` — use the actual default branch name; fall back to the local default branch if no remote is configured). The merge-base anchors the diff at the branch's fork point — and, when working directly on the default branch, at the last pushed commit — so it covers branch commits **and uncommitted working-tree changes** without pulling in unrelated upstream commits. Do not fetch a PR; skip the PR discovery and eligibility checks in Steps 1–2 entirely (do not stop or ask for a PR). Still gather the rules context Step 3 needs: list the project rule files loaded for this repository (the agent's own rules directory, wherever the platform keeps it).
-- Run the Step 3 review agents and the Step 4 confidence scoring over that scope — the diff plus the untracked files — exactly as written.
-- **Apply** the surviving findings directly to the working tree and fold them into the commit being pushed. Skip the `AskUserQuestion` gate (Step 6), the separate `claude/review-fixes-*` branch (Step 7), and Step 8 entirely — never post a comment in this mode. Step 5's “skip to step 8” does not apply here: if no findings survive the filter, report that in your reply and conclude.
-
-Use the full PR flow (Steps 1–2, 6–8, and the comment format) **only** when reviewing an actual GitHub PR.
-
 ## Steps 1–2 — PR discovery and context
 
 **Step 1:** Read and execute **Step 1** of the **scope-agents** skill (repository discovery and PR detection). This returns the repository structure and — if a PR is detectable — its number and repo slug.
 
-If no PR is detected and you are reviewing a PR (not in local / pre-push mode), stop and ask the user to provide a PR number or URL.
+If no PR is detected, stop and ask the user to provide a PR number or URL.
 
 Then use a Haiku agent to check eligibility: stop without proceeding if the PR is (a) closed, (b) a draft, (c) clearly automated or trivially simple and obviously fine, or (d) already has a code review comment from you **for the PR's current head commit** — a new push since your last review makes the PR eligible again.
 
@@ -34,10 +24,10 @@ Then use a Haiku agent to check eligibility: stop without proceeding if the PR i
 
 ## Steps 3–8 — Review, scoring, approval, fixes, report
 
-Follow these steps precisely (in local / pre-push mode, the **Local / pre-push mode** section above replaces Steps 1–2 and overrides Steps 6–8):
+Follow these steps precisely:
 
-3. Launch **5 parallel Sonnet agents** to independently review the diff (the PR diff, or the local branch diff in local / pre-push mode). Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
-   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2, or locally in local / pre-push mode). Note that the rules are guidance for code generation, so not all instructions apply during review.
+3. Launch **5 parallel Sonnet agents** to independently review the PR diff. Each agent reads the changed files and returns a flat list of issues with the reason each was flagged (e.g. rule compliance, bug, historical context):
+   - Agent #1 (rules): Audit the changes for compliance with the project rule files gathered earlier (Step 2). Note that the rules are guidance for code generation, so not all instructions apply during review.
    - Agent #2 (bugs): Scan the diff for obvious bugs. Focus on large bugs; ignore nitpicks and likely false positives. You may read surrounding context in the touched files; pre-existing bugs in those files are in scope.
    - Agent #3 (history): Read git blame and history of the changed files; flag bugs that only make sense in light of that history.
    - Agent #4 (prior PRs): Read previous pull requests that touched the same files; check whether comments on those PRs also apply here.
@@ -52,13 +42,13 @@ Follow these steps precisely (in local / pre-push mode, the **Local / pre-push m
 
    For rule-compliance issues: double-check that the rule file actually calls out that specific issue before scoring above 50.
 
-5. Filter out issues with a score below 80. If none remain, skip to step 8 (in local / pre-push mode: report that no findings survived and conclude — no comment).
+5. Filter out issues with a score below 80. If none remain, skip to step 8.
 
-6. *(PR flow only — skipped in local / pre-push mode.)* **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
+6. **You must call `AskUserQuestion` before applying any fix.** Present up to 4 issues per batch, asking for each: "Fix this? (yes / skip)". Wait for responses before the next batch. Record every decision.
 
-7. *(In local / pre-push mode: apply every finding that survived Step 5 directly to the working tree — no approval gate, no separate branch.)* In the PR flow, implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
+7. Implement every finding the user approved. Before editing any file, create a git branch following the naming convention in **scope-agents** (e.g. `claude/review-fixes-a3f9b2c`) and commit all fixes to that branch. Keep each fix minimal — do not refactor unrelated code.
 
-8. *(PR flow only — never post a comment in local / pre-push mode.)* Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
+8. Use a Haiku agent to repeat the eligibility check from Step 1. If still eligible, post a comment using `gh pr comment <number> --body "..."`. Follow the comment format below.
 
 ## False Positives to Ignore
 


### PR DESCRIPTION
Adjusts the agent tooling around the Stop-hook pre-push pass (all in `.agents/`, synced into the `.claude/` and `.cursor/` mirrors):

**`simplify-on-stop.sh`**
- **Runs `code-simplify` only.** `claude-review` is dropped from the pre-push pass; the hook now nudges for `code-simplify` alone over the whole branch diff.
- **Reverts the once-per-branch gating.** Back to the per-state stamp keyed on `HEAD` + working-tree content, so the pass fires again whenever the branch's content changes.

**`claude-review` skill**
- **Reverts to PR-only mode.** Removes the local / pre-push mode; the skill reviews an actual GitHub PR again (the hook no longer invokes it). Keeps the pre-existing-issues-in-scope note.

Retains the hook edge-case handling from prior rounds: `stop_hook_active` loop guard, `is-inside-work-tree`/git-dir guard, `status-error` fail-safe, binary-safe + portable working-tree hashing, and origin/main-or-master default detection.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent hook and skill documentation only; no application runtime or security paths change.
> 
> **Overview**
> Narrows the **Stop** hook pre-push pass to **`code-simplify` only** and drops **`claude-review`** from the blocked reason (mirrored under `.agents/`, `.claude/`, and `.cursor/`).
> 
> **`simplify-on-stop.sh`** replaces **once-per-branch** tracking (`simplify-on-stop.nudged` + branch/detached fork keys) with a **`HEAD` + working-tree content stamp** (`simplify-on-stop.stamp`), so the nudge can fire again when commits or uncommitted/untracked content change. The block message now instructs a single local **`code-simplify`** pass over the full branch diff (commit and push if needed).
> 
> **`claude-review` skill** removes the **local / pre-push** section and PR-flow exceptions; reviews are **GitHub PR–only** again (same text synced in `.agents/`, `.claude/`, `.codex/`, `.cursor/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990dfd3043ef863f842ca1d64e08b0edbde03a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->