### PR TITLE
ci: add Claude review routine workflow on PR open/commit

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,55 @@
+name: Claude Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+# One in-flight fire per PR; a newer commit cancels a superseded run.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fire-review-routine:
+    name: Fire Claude review routine
+    if: >-
+      ${{ github.event.pull_request.head.repo.full_name == github.repository
+          && github.event.sender.type != 'Bot'
+          && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire routine
+        env:
+          CLAUDE_REVIEW_ROUTINE_API_KEY: ${{ secrets.CLAUDE_REVIEW_ROUTINE_API_KEY }}
+          CLAUDE_REVIEW_ROUTINE_ID: ${{ secrets.CLAUDE_REVIEW_ROUTINE_ID }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ -z "$CLAUDE_REVIEW_ROUTINE_API_KEY" ] || [ -z "$CLAUDE_REVIEW_ROUTINE_ID" ]; then
+            echo "CLAUDE_REVIEW_ROUTINE_API_KEY or CLAUDE_REVIEW_ROUTINE_ID is unset; skipping."
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg repo "$REPO" \
+            --arg num "$PR_NUMBER" \
+            --arg url "$PR_URL" \
+            --arg ref "$HEAD_REF" \
+            --arg author "$PR_AUTHOR" \
+            --arg sha "$HEAD_SHA" \
+            '{text: "Review pull request #\($num) (\($url)) in repo \($repo), on branch \($ref), opened by \($author), triggered by commit \($sha)."}')
+
+          curl --fail-with-body -sS -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${CLAUDE_REVIEW_ROUTINE_ID}/fire" \
+            -H "Authorization: Bearer $CLAUDE_REVIEW_ROUTINE_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "$payload"


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml`. On `pull_request` `opened`/`synchronize`, it fires the configured Claude Code review routine via the Anthropic API (`POST /v1/claude_code/routines/${CLAUDE_REVIEW_ROUTINE_ID}/fire`).

Guardrails:
- **Skips if unconfigured** — exits cleanly when the `CLAUDE_REVIEW_ROUTINE_API_KEY` or `CLAUDE_REVIEW_ROUTINE_ID` secret is unset.
- **Skips bot-authored events** (`github.event.sender.type != 'Bot'`).
- **Maintainers only** — runs only when the PR author's association is `OWNER`/`MEMBER`/`COLLABORATOR`, so external users can't consume the API key (fork PRs also don't receive secrets on `pull_request`).

The fired routine receives a `text` turn with context: repo, PR number/URL, branch, author, and the triggering commit SHA.

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no app/runtime impact; API key use is gated by secrets and author checks, though misconfigured secrets would silently skip reviews.
> 
> **Overview**
> Adds **`.github/workflows/claude-review.yml`**, which on `pull_request` **opened** and **synchronize** POSTs to Anthropic’s Claude Code **routine fire** API so an external review routine runs for the PR.
> 
> The job uses **read-only** `contents` permission, **per-PR concurrency** with cancel-in-progress, and **conditional execution**: same-repo head only, non-bot sender, and PR author association in `OWNER` / `MEMBER` / `COLLABORATOR`. If `CLAUDE_REVIEW_ROUTINE_API_KEY` or `CLAUDE_REVIEW_ROUTINE_ID` is missing, the step exits 0 without calling the API. The JSON payload’s `text` field includes repo, PR number/URL, branch, author, and head SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5013ffa2e893f2e28f6ef6ad0acba99a5b653863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->