### PR TITLE
chore(deps): update pydantic-super-model to 2.0.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1040,22 +1040,22 @@ yaml = ["pyyaml (>=6.0.1)"]
 
 [[package]]
 name = "pydantic-super-model"
-version = "2.0.0"
+version = "2.0.1"
 description = "Lightweight mixin for generic introspection and Annotated field lookup"
 optional = false
 python-versions = "<3.15,>=3.11"
 groups = ["main"]
 files = [
-    {file = "pydantic_super_model-2.0.0-py3-none-any.whl", hash = "sha256:2284d598d061b7ed473b96704575d749f3b23dfbb4bd78e074af589c6fb67a84"},
-    {file = "pydantic_super_model-2.0.0.tar.gz", hash = "sha256:3bb026160c279c9de1f2e4c36fd677b4f63c6835bce64591a924d96ba3623e60"},
+    {file = "pydantic_super_model-2.0.1-py3-none-any.whl", hash = "sha256:027594314cbace3ebb1944be08c6008faf4a7fa39a4c2194a0aafb59e1e5795c"},
+    {file = "pydantic_super_model-2.0.1.tar.gz", hash = "sha256:aaedb496d2f2f21fa59ec7eefbf601fc6bcd869a8147b0851a6318b68d1b5345"},
 ]
 
 [package.dependencies]
-pydantic = ">=2.11.7"
-python-generics = ">=0.2.3"
+pydantic = ">=2.13.4"
+python-generics = ">=0.2.4"
 
 [package.extras]
-dev = ["black", "coverage (>=7.6)", "isort", "pylint", "pytest (>=8.0)", "pytest-asyncio (>=0.23)", "pytest-cov (>=6.1.1)"]
+dev = ["black (>=26.5.1)", "coverage (>=7.15.0)", "isort (>=8.0.1)", "pylint (>=4.0.6)", "pytest (>=9.1.1)", "pytest-asyncio (>=1.4.0)", "pytest-cov (>=7.1.0)"]
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
## Summary

Refreshes the Poetry lockfile to pick up the latest published version of the `pydantic-super-model` dependency.

- `pydantic-super-model` 2.0.0 → 2.0.1

No source changes were required; the update is a lockfile-only bump.

## Testing

- `poetry run pytest` (Python 3.12) — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcpmU79GYmJ32j67t4Q2U8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcpmU79GYmJ32j67t4Q2U8)_

<!-- code-review:summary:start -->
---
<!-- UNTRUSTED_INPUT START -->
### Summary
- Bumps `pydantic-super-model` from 2.0.0 to 2.0.1 in `poetry.lock`.
- Raises the minimum `pydantic` requirement from `>=2.11.7` to `>=2.13.4`.
- Raises the minimum `python-generics` requirement from `>=0.2.3` to `>=0.2.4`.
- Updates pinned wheel and source distribution hashes for the new `pydantic-super-model` release.
- Refreshes `pydantic-super-model` dev dependency version constraints (e.g. Black, pytest, pylint).

**Low Risk** — This is a patch-level dependency update confined to the lockfile, with no application source changes.

### Overview
This pull request updates the Poetry lockfile to pull in `pydantic-super-model` 2.0.1 and its revised dependency constraints. The change affects only `poetry.lock`: package versions, artifact hashes, and minimum versions for `pydantic`, `python-generics`, and development tooling tied to that package. No library or application code is modified.
<!-- UNTRUSTED_INPUT END -->

_This response was AI generated by [code-review-action](https://github.com/julien777z/code-review-action)._
<!-- code-review:summary:end -->