### PR TITLE
chore: sync agent files

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -5,10 +5,6 @@ description: Review the complete pull-request diff for the current branch with h
 
 # Code Review
 
-## Dependencies
-
-- `code-review-loop` — provides the iterative review-and-fix workflow that invokes this review pass.
-
 Perform one high-signal review pass over the complete selected review target. Establish the PR when needed, but do not modify code to fix findings. In manual runs, report only in the current chat. A preceding CI adapter may explicitly adapt PR discovery, review orchestration, and output mechanics; the workflow runner, never this skill, owns GitHub review posting.
 
 **Scope — review only the selected review target.** Every finding must anchor to an added or removed line in that target's diff. Do not report pre-existing issues on untouched lines, even in modified files.

--- a/.agents/skills/coordinate-repositories/SKILL.md
+++ b/.agents/skills/coordinate-repositories/SKILL.md
@@ -13,10 +13,13 @@ Carry out the caller's task consistently across the selected repository collecti
 2. For each candidate, read the relevant files and enough local guidance to understand whether the task applies. Keep repository-specific behavior unless the caller explicitly requests a unification.
 3. Choose the task mode:
    - For a read-only task, gather evidence from every applicable repository and merge it into one clearly attributed result.
-   - For a change or review-and-fix task, work only in an isolated worktree based on that repository's remote default branch. Leave the original checkout, branch, and unrelated dirty work untouched.
-4. Carry only the user-authorized task artifacts into each isolated worktree. Do not copy unrelated in-progress changes, generated outputs, credentials, or machine-specific configuration.
-5. Validate each completed repository with the relevant native checks. If the task manages generated files, use its owning generator rather than hand-editing generated outputs.
-6. Before selecting a worktree or reusing a pull request, query the hosting service for the pull request associated with the candidate branch and verify its current state, branch, and task scope. Never infer that a pull request is active from a local branch, remote-tracking branch, remembered URL, or prior task output. Treat a merged, closed, missing, or branch-deleted pull request as absent: create a fresh isolated worktree and a new branch from the current remote default branch, then open a new focused pull request. Never append work to the old branch or push it merely because it remains locally available. Reuse only a verified open pull request for the same active branch and task scope.
+   - For a change or review-and-fix task, before selecting a worktree or branch, query the hosting service for an open pull request whose current head branch and task scope match the candidate. Verify its current state, exact remote head branch, and task scope. Never treat a local branch, remote-tracking branch, remembered URL, or prior task output as evidence that a pull request should receive new work.
+4. For a change or review-and-fix task:
+   - When a verified matching pull request is open, create an isolated worktree from that pull request's remote head branch and update only that pull request.
+   - When no verified matching pull request is open—or it is merged, closed, missing, or its branch was deleted—create a fresh isolated worktree from the current remote default branch and a new collision-free branch. When the user authorizes persistent changes, validate first, then commit, push, and open a new focused pull request.
+   - In every case, leave the original checkout, branch, and unrelated dirty or in-progress work untouched.
+5. Carry only the user-authorized task artifacts into each isolated worktree. Do not copy unrelated in-progress changes, generated outputs, credentials, or machine-specific configuration.
+6. Validate each completed repository with the relevant native checks. If the task manages generated files, use its owning generator rather than hand-editing generated outputs.
 7. Report every repository completed, skipped, or blocked; the applied or gathered result; validation; and all pull-request links created or updated.
 
 ## Guardrails


### PR DESCRIPTION
## Summary
- require PR discovery before choosing a cross-repository worktree or branch
- reuse only a verified scope-matching PR; otherwise use a fresh default-branch worktree and focused PR
- remove the invalid reverse `code-review` -> `code-review-loop` dependency

## Validation
- quick_validate.py for changed skills
- git diff --check